### PR TITLE
Fixed homepage text link

### DIFF
--- a/src/gatsby-theme-carbon/templates/Homepage.js
+++ b/src/gatsby-theme-carbon/templates/Homepage.js
@@ -24,7 +24,7 @@ const FirstRightText = () => (
     <br />
     <p>
       Support includes{' '}
-      <a href="/tools-and-resources/overview">tools and resources</a> to help
+      <a href="tools-and-resources/overview">tools and resources</a> to help
       make remote learning effective and guidance for your role in the school
       community.
     </p>


### PR DESCRIPTION
The link to the overview page for "tools and resources" was absolute to ibm.com, not relative to ibm.com/remotelearning.